### PR TITLE
Add test dependencies goal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,5 +83,10 @@
 			<artifactId>commons-io</artifactId>
 			<version>2.4</version>
 		</dependency>
+		<dependency>
+			<groupId>org.twdata.maven</groupId>
+			<artifactId>mojo-executor</artifactId>
+			<version>2.2.0</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/ca/mestevens/unity/CopyTestDependenciesMojo.java
+++ b/src/main/java/ca/mestevens/unity/CopyTestDependenciesMojo.java
@@ -59,6 +59,11 @@ public class CopyTestDependenciesMojo extends AbstractMojo {
 		final File testDependencyDirectoryFile = new File(String.format("%s/test-dependency", this.projectBuildDirectory));
 		final File testPluginsDirectoryFile = new File(String.format("%s/%s", this.mavenProject.getBasedir(), this.testPluginsDirectory));
 
+		if (!testDependencyDirectoryFile.exists()) {
+			this.getLog().info("No test dependencies detected");
+			return;
+		}
+
 		try {
 			final FileFilter fileFilter = new WildcardFileFilter("*.dll");
 			final List<File> testDependencies = Lists.newArrayList(testDependencyDirectoryFile.listFiles(fileFilter));

--- a/src/main/java/ca/mestevens/unity/CopyTestDependenciesMojo.java
+++ b/src/main/java/ca/mestevens/unity/CopyTestDependenciesMojo.java
@@ -1,0 +1,76 @@
+package ca.mestevens.unity;
+
+import com.google.common.collect.Lists;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.WildcardFileFilter;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.BuildPluginManager;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.util.List;
+
+import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
+
+@Mojo(name = "unity-copy-test-dependencies", requiresDependencyResolution = ResolutionScope.TEST)
+public class CopyTestDependenciesMojo extends AbstractMojo {
+
+	@Component
+	private MavenProject mavenProject;
+
+	@Component
+	private MavenSession mavenSession;
+
+	@Component
+	private BuildPluginManager pluginManager;
+
+	@Parameter(property = "project.build.directory", required = true, readonly = true)
+	private String projectBuildDirectory;
+
+	@Parameter(property = "unity.plugins.directory", defaultValue = "Assets/Editor/Plugins", required = true, readonly = true)
+	private String testPluginsDirectory;
+
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException {
+
+		executeMojo(
+				plugin(
+						groupId("org.apache.maven.plugins"),
+						artifactId("maven-dependency-plugin"),
+						version("2.0")
+				),
+				goal("copy-dependencies"),
+				configuration(
+						element(name("outputDirectory"), "${project.build.directory}/test-dependency"),
+						element(name("excludeScope"), "compile")
+				),
+				executionEnvironment(
+						mavenProject, mavenSession, pluginManager));
+
+		final File testDependencyDirectoryFile = new File(String.format("%s/test-dependency", this.projectBuildDirectory));
+		final File testPluginsDirectoryFile = new File(String.format("%s/%s", this.mavenProject.getBasedir(), this.testPluginsDirectory));
+
+		try {
+			final FileFilter fileFilter = new WildcardFileFilter("*.dll");
+			final List<File> testDependencies = Lists.newArrayList(testDependencyDirectoryFile.listFiles(fileFilter));
+			for (final File dependency : testDependencies) {
+				this.getLog().info(String.format("Copying [%s] to [%s]", dependency.getName(), this.testPluginsDirectory));
+				FileUtils.copyFileToDirectory(dependency, testPluginsDirectoryFile);
+			}
+		} catch (final IOException e) {
+			this.getLog().error("Failed to copy dependencies", e);
+			throw new MojoFailureException("Failed to copy dependencies", e);
+		}
+
+	}
+
+}

--- a/src/main/java/ca/mestevens/unity/FrameworkDependenciesMojo.java
+++ b/src/main/java/ca/mestevens/unity/FrameworkDependenciesMojo.java
@@ -79,17 +79,6 @@ public class FrameworkDependenciesMojo extends AbstractMojo {
 		
 		File resultFile = new File(String.format("%s/%s", this.project.getBasedir(), this.pluginsDirectory));
 		this.getLog().info(String.format("Resolved [%s] artifacts, copying to plugins directory [%s]", resolvedArtifacts.size(), resultFile.getAbsolutePath()));
-
-		try {
-			if (resultFile.exists()) {
-				FileUtils.deleteDirectory(resultFile);
-			}
-			FileUtils.mkdir(resultFile.getAbsolutePath());
-		} catch (IOException e) {
-			getLog().error("Problem deleting or creating plugin folder at: " + resultFile.getAbsolutePath());
-			getLog().error(e.getMessage());
-			throw new MojoFailureException("Problem deleting or creating plugin folder at: " + resultFile.getAbsolutePath());
-		}
 		
 		for (ArtifactResult resolvedArtifact : resolvedArtifacts) {
 			Artifact artifact = resolvedArtifact.getArtifact();
@@ -104,18 +93,6 @@ public class FrameworkDependenciesMojo extends AbstractMojo {
 			}
 
 			if (typePropertyValue.equals(UNITY_LIBRARY)) {
-
-				//Check if Assets/Plugins/iOS exists, if not create it
-				final File iosPluginsDirectory = new File(String.format("%s/Assets/Plugins/iOS", this.project.getBasedir()));
-				if(!iosPluginsDirectory.exists()) {
-					FileUtils.mkdir(iosPluginsDirectory.getAbsolutePath());
-				}
-
-				//Check if Assets/Plugins/Android exists, if not create it
-				final File androidPluginsDirectory = new File(String.format("%s/Assets/Plugins/Android", this.project.getBasedir()));
-				if(!androidPluginsDirectory.exists()) {
-					FileUtils.mkdir(androidPluginsDirectory.getAbsolutePath());
-				}
 
 				try {
 					Artifact ab = new DefaultArtifact(artifact.getGroupId(), artifact.getArtifactId(), "ios-plugin",

--- a/src/main/java/ca/mestevens/unity/InitializeMojo.java
+++ b/src/main/java/ca/mestevens/unity/InitializeMojo.java
@@ -1,0 +1,78 @@
+package ca.mestevens.unity;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Binds to initialize phase.
+ * Creates all required directories including:
+ * - Plugins directory
+ * - Test plugins directory
+ * - iOS plugins directory
+ * - Android plugins directory
+ */
+@Mojo(name = "unity-initialize")
+public class InitializeMojo extends AbstractMojo {
+
+	@Parameter(property = "project", readonly = true, required = true)
+	public MavenProject project;
+
+	@Parameter(property = "unity.plugins.directory", defaultValue = "Assets/Runtime/Plugins", readonly = true, required = true)
+	public String pluginsDirectory;
+
+	@Parameter(property = "unity.test.plugins.directory", defaultValue = "Assets/Editor/Plugins", readonly = true, required = true)
+	public String testPluginsDirectory;
+
+	@Parameter(property = "unity.ios.plugins.directory", defaultValue = "Assets/Plugins/iOS", readonly = true, required = true)
+	public String iosPlusinsDirectory;
+
+	@Parameter(property = "unity.android.plugins.directory", defaultValue = "Assets/Plugins/Android", readonly = true, required = true)
+	public String androidPluginsDirectory;
+
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException {
+
+		this.getLog().info("Executing unity:unity-initialize");
+
+		final File pluginsDirectoryFile = new File(String.format("%s/%s", this.project.getBasedir(), this.pluginsDirectory));
+		final File testPluginsDirectoryFile = new File(String.format("%s/%s", this.project.getBasedir(), this.testPluginsDirectory));
+		final File iosPluginsDirectoryFile = new File(String.format("%s/%s", this.project.getBasedir(), this.iosPlusinsDirectory));
+		final File androidPluginsDirectoryFile = new File(String.format("%s/%s", this.project.getBasedir(), this.androidPluginsDirectory));
+
+		try {
+			if (pluginsDirectoryFile.exists()) {
+				FileUtils.deleteDirectory(pluginsDirectoryFile);
+			}
+
+			if (testPluginsDirectoryFile.exists()) {
+				FileUtils.deleteDirectory(testPluginsDirectoryFile);
+			}
+
+			if (iosPluginsDirectoryFile.exists()) {
+				FileUtils.deleteDirectory(iosPluginsDirectoryFile);
+			}
+
+			if (androidPluginsDirectoryFile.exists()) {
+				FileUtils.deleteDirectory(androidPluginsDirectoryFile);
+			}
+		} catch (final IOException e) {
+			this.getLog().error("Failed to clean up existing plugins directories", e);
+			throw new MojoFailureException("Failed to clean up existing plugins directories", e);
+		}
+
+		FileUtils.mkdir(pluginsDirectoryFile.getAbsolutePath());
+		FileUtils.mkdir(testPluginsDirectoryFile.getAbsolutePath());
+		FileUtils.mkdir(iosPluginsDirectoryFile.getAbsolutePath());
+		FileUtils.mkdir(androidPluginsDirectoryFile.getAbsolutePath());
+
+	}
+
+}

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -23,7 +23,9 @@
 						<id>default</id>
 						<phases>
 							<initialize>
-								ca.mestevens.unity:unity-maven-plugin:unity-library-dependencies
+								ca.mestevens.unity:unity-maven-plugin:unity-initialize,
+								ca.mestevens.unity:unity-maven-plugin:unity-library-dependencies,
+								ca.mestevens.unity:unity-maven-plugin:unity-copy-test-dependencies
 							</initialize>
 							<compile>
 								ca.mestevens.unity:unity-maven-plugin:unity-android-build
@@ -86,7 +88,9 @@
 						<id>default</id>
 						<phases>
 							<initialize>
-								ca.mestevens.unity:unity-maven-plugin:unity-library-dependencies
+								ca.mestevens.unity:unity-maven-plugin:unity-initialize,
+								ca.mestevens.unity:unity-maven-plugin:unity-library-dependencies,
+								ca.mestevens.unity:unity-maven-plugin:unity-copy-test-dependencies
 							</initialize>
 							<compile>
 								ca.mestevens.unity:unity-maven-plugin:unity-build-dll


### PR DESCRIPTION
There are 3 goals now:
1. `unity-initialize` - Which cleans up existing directories and creates required plugin folders
1. `unity-library-dependencies` - Does exactly what it did before, minus directory creation
1. `unity-copy-test-dependencies` - Which deals exclusively with test dependencies.  This actually makes a call out to the dependencies plugin to copy test dependencies to the target directory, then we move them into the Assets/Editor/Plugins directory

All of these goals run in sequence and are bound to the `initialize` phase
